### PR TITLE
 Add Invite Modal for Team Member Management

### DIFF
--- a/src/Component/Common/Invite/Invite.jsx
+++ b/src/Component/Common/Invite/Invite.jsx
@@ -1,0 +1,135 @@
+
+//#region imports
+import { Avatar, Box, Button, IconButton, MenuItem, Modal, Select, TextField, Typography } from '@mui/material';
+import React, { useState } from 'react';
+import CloseIcon from '@mui/icons-material/Close';
+import Members from './Members';
+//#endregion
+
+//#region Component make Styles
+//#endregion
+
+//#region Function Component
+const Invite = ({ openInvite, handleClose }) => {
+  //#region Component states
+ const [memberDetail , setMemberDetail] = useState(true)
+  //#endregion
+
+  //#region Component hooks
+   React.useEffect(() => {
+      // Anything in here is fired on component mount.
+      return () => {
+          // Anything in here is fired on component unmount.
+      }
+    }, [])
+
+   React.useEffect(() => {
+      // Anything in here is fired on component update.
+   });
+  //#endregion
+
+  //#region Component use Styles
+  //#endregion
+
+  //#region Component validation methods
+  //#endregion
+
+  //#region Component Api methods
+ 
+  //#endregion
+
+  //#region Component feature methods
+  
+  //#endregion
+
+  //#region Component JSX.members
+  const membersList = [
+  { firstName: 'Varsha Roy',lastName : 'Roy', email: 'varsharoy@gmail.com', avatar: 'https://i.pravatar.cc/150?img=1', role: 'Can edit' },
+  { firstName: 'Raj Aaran',lastName : 'Roy', email: 'rajayaran@gmail.com', avatar: 'https://i.pravatar.cc/150?img=2', role: 'Can edit' },
+  { firstName: 'Harsh Raj',lastName : 'Roy', email: 'rajharsh@gmail.com', avatar: 'https://i.pravatar.cc/150?img=3', role: 'Owner' },
+  { firstName: 'Riya Joe',lastName : 'Roy', email: 'joeriya@gmail.com', avatar: 'https://i.pravatar.cc/150?img=4', role: 'Can edit' },
+];
+
+const user =[{
+    _id : 1
+    ,firstName : 'Harsh',
+    lastName : 'Raj',
+    email: 'harhs@gmail.com',
+    profile: ''
+  }]
+
+  const formateData = memberDetail ? membersList : user
+  //#endregion
+
+  //#region Component renders
+  return(
+    <Modal open={openInvite} onClose={handleClose}>
+      <Box sx={{
+        position: 'absolute',
+        top: '50%',
+        left: '50%',
+        transform: 'translate(-50%, -50%)',
+        width: '70vw',
+        height:'80vh',
+        backgroundColor: 'white' ,
+        borderRadius: 2,
+        boxShadow: 24,
+        p: 3,
+        overflow: 'auto',
+       '&::-webkit-scrollbar': {
+            display: 'none',
+        },
+        }}>
+        <Box display="flex" justifyContent="space-between" alignItems="center">
+          <Typography variant="h6" >
+            Send an invite to a new member
+          </Typography>
+          <Typography onClick={handleClose} color='primary' sx={{textDecoration: 'underline', cursor: 'pointer'}}> Go Back</Typography>
+          
+        </Box>
+
+        <Box mt={2} sx={{display:'flex', gap:2}}>
+          <TextField
+            fullWidth
+            variant="outlined"
+            label="Email"          
+          />
+          <Button
+            variant="contained"
+            sx={{ backgroundColor: '#f44336' ,width : '20%' }}
+          >
+            Send Invite
+          </Button>
+        </Box>
+
+        <Box mt={4}>
+          <Box sx={{display: 'flex', gap: 2}}>
+            <Typography variant="subtitle1" fontWeight="bold" onClick={() => setMemberDetail(true) } sx={{ cursor:'pointer' , opacity: !memberDetail ? 0.6 : 1}}>Members</Typography>
+            <Typography variant="subtitle1" fontWeight="bold" onClick={() => setMemberDetail(false) } sx={{ cursor:'pointer' , opacity: memberDetail ? 0.6 : 1}}>Pending Requests</Typography>
+          </Box>
+          {formateData.map((user, index) => (
+            <Members user={user} index={index} memberDetail={memberDetail}/>
+          ))}
+        </Box>
+
+        <Box mt={4}>
+          <Typography variant="subtitle1" fontWeight="bold">Team Invite Link</Typography>
+          <Box display="flex" gap={1} >
+            <TextField
+              fullWidth
+              variant="outlined"
+              placeholder='link'
+            />
+            <Button variant="contained" sx={{width: '20%' , backgroundColor: '#f44336'}}>Copy Link</Button>
+          </Box>
+        </Box>
+      </Box>
+    </Modal>
+  );
+  //#endregion
+}
+//#endregion
+
+//#region Component export
+export default Invite;
+//#endregion

--- a/src/Component/Common/Invite/Members.jsx
+++ b/src/Component/Common/Invite/Members.jsx
@@ -1,0 +1,78 @@
+
+//#region imports
+import { Avatar, Box, MenuItem, Select, Typography } from '@mui/material';
+import React from 'react';
+//#endregion
+
+//#region Component make Styles
+//#endregion
+
+//#region Function Component
+const Members = ({user ,index,memberDetail}) => {
+  //#region Component states
+  //#endregion
+
+  //#region Component hooks
+   React.useEffect(() => {
+      // Anything in here is fired on component mount.
+      return () => {
+          // Anything in here is fired on component unmount.
+      }
+    }, [])
+
+   React.useEffect(() => {
+      // Anything in here is fired on component update.
+   });
+  //#endregion
+
+  //#region Component use Styles
+  //#endregion
+
+  //#region Component validation methods
+  //#endregion
+
+  //#region Component Api methods
+  //#endregion
+
+  //#region Component feature methods
+  const handleCancelClick = () => {
+    console.log('cancel clicked');
+  }
+  //#endregion
+
+  //#region Component JSX.members
+  
+  const ownerId = 1
+  //#endregion
+
+  //#region Component renders
+  return(
+    <Box key={index} display="flex" alignItems="center" justifyContent="space-between" mt={2}>
+        <Box display="flex" alignItems="center">
+            <Avatar src={user.avatar} sx={{ mr: 2 }} />
+            <Box>
+                <Typography>{user.firstName +' '+ user.lastName}</Typography>
+                <Typography variant="body2" color="text.secondary">{user.email}</Typography>
+            </Box>
+        </Box>
+
+    {memberDetail ? 
+     <Typography sx={{border: '2px solid #E57373' , padding:'0.5rem 2rem'}}>
+        {user._id === ownerId ? 'Owner' : 'Member'}
+    </Typography> 
+    :
+    <Typography sx={{border: '2px solid #E57373' , padding:'0.5rem 2rem'}} onClick={handleCancelClick}>
+        Cancel
+    </Typography>
+    }
+   
+       
+    </Box>
+  );
+  //#endregion
+}
+//#endregion
+
+//#region Component export
+export default Members;
+//#endregion

--- a/src/Component/Common/SideNavBar/SideNav.jsx
+++ b/src/Component/Common/SideNavBar/SideNav.jsx
@@ -12,8 +12,8 @@ import { Link, useLocation } from 'react-router-dom';
 //#region Component objects
   const menuItems = [
     { name: 'Dashboard', icon: <DashboardIcon size={20} />, link: '/dashboard' },
-    { name: 'My Expense', icon: <ReceiptIcon size={20} />, link: '/myexpense' },
-    { name: 'Team Expense', icon: <GroupsIcon size={20} />, link: '/expenselist' },
+    { name: 'My Expense', icon: <ReceiptIcon size={20} />, link: '/expenselist' },
+    { name: 'Team Expense', icon: <GroupsIcon size={20} />, link: '/teamexpense' },
     { name: 'Settings', icon: <SettingsIcon size={20} />, link: '/setting' },
     { name: 'Help', icon: <HelpIcon size={20} />, link: '/help' }
   ];

--- a/src/Component/Common/TeamCart/TeamCart.jsx
+++ b/src/Component/Common/TeamCart/TeamCart.jsx
@@ -5,7 +5,7 @@ import React from 'react';
 import GroupAddIcon from '@mui/icons-material/GroupAdd';
 import img from '../../../assets/profile.jpg';
 import { red } from '@mui/material/colors';
-import { Link } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router-dom';
 
 //#endregion
 
@@ -13,8 +13,9 @@ import { Link } from 'react-router-dom';
 //#endregion
 
 //#region Function Component
-const TeamCart = ({teamDetails}) => {
+const TeamCart = ({teamDetails ,setOpenInvite }) => {
     const {teamName ,totAmount ,topCategory ,yourContribution ,lastTransaction} = teamDetails
+    const navigate = useNavigate();
   //#region Component states
   // const navigate = useNavigate()
   //#endregion
@@ -36,6 +37,9 @@ const TeamCart = ({teamDetails}) => {
   //#endregion
 
   //#region Component validation methods
+  const handleTeamExpenseNavigation = () => {
+    navigate('/expenselist')
+  }
   //#endregion
 
   //#region Component Api methods
@@ -61,8 +65,7 @@ const TeamCart = ({teamDetails}) => {
 
   //#region Component renders
   return(
-     <Link to={'/expenselist'}>
-    <Card  variant="outlined"  sx={{ borderRadius: 3, padding: 2 , bgcolor: '#F5F8FF', marginY: 2, boxShadow: 3}}>
+    <Card  variant="outlined" onClick={handleTeamExpenseNavigation}  sx={{ borderRadius: 3, padding: 2 , bgcolor: '#F5F8FF', marginY: 2, boxShadow: 3}}>
       <CardContent>
         <Box display="flex" alignItems="center" gap={1} mb={1}>
           <Typography variant="h6" fontWeight="bold">
@@ -111,6 +114,7 @@ const TeamCart = ({teamDetails}) => {
             variant="outlined"
             size="small"
             startIcon={<GroupAddIcon />}
+            onClick={ setOpenInvite }
             sx={{ borderRadius: 3, textTransform: 'none' ,color: red[400]}}
           >
             Invite
@@ -127,7 +131,6 @@ const TeamCart = ({teamDetails}) => {
         </Box>
       </CardContent>
     </Card>
-    </Link>
   );
   //#endregion
 }

--- a/src/Component/Common/TeamTracker/TeamTracker.jsx
+++ b/src/Component/Common/TeamTracker/TeamTracker.jsx
@@ -12,7 +12,7 @@ import { Groups  } from '@mui/icons-material';
 //#endregion
 
 //#region Function Component
-const TeamTracker = ({teamDetails, setCreateTeam}) => {
+const TeamTracker = ({teamDetails, setCreateTeam , openInvite , setOpenInvite, handleClose}) => {
   //#region Component states
   
   //#endregion
@@ -90,6 +90,9 @@ const TeamTracker = ({teamDetails, setCreateTeam}) => {
                 {teamDetails.map((teamDetail)=>(
                  <TeamCart
                     teamDetails={teamDetail}
+                    openInvite ={openInvite}
+                    handleClose ={handleClose}
+                    setOpenInvite ={setOpenInvite}
             />
             ))}
             </Box>

--- a/src/Component/Pages/Dashboard/Dashboard.jsx
+++ b/src/Component/Pages/Dashboard/Dashboard.jsx
@@ -8,6 +8,7 @@ import TeamTracker from '../../Common/TeamTracker/TeamTracker';
 import PersonalTracker from '../../Common/PersonalTracker/PersonalTracker';
 import AddTeam from '../../Common/AddTeam/AddTeam'
 import AddExpense from '../../Common/AddExpense/AddExpense';
+import Invite from '../../Common/Invite/Invite';
 
 
 //#endregion
@@ -20,6 +21,7 @@ const Dashboard = () => {
   //#region Component states
   const [createTeam, setCreateTeam] = useState(false)
   const [openAddExpense, setOpenAddExpense] = useState(false);
+  const [openInvite , setOpenInvite] = useState(false );
   //#endregion
 
   //#region Component hooks
@@ -39,6 +41,10 @@ const Dashboard = () => {
   //#endregion
 
   //#region Component validation methods
+  const handleInviteButtonClick = (e) => {
+    e.stopPropagation();
+    setOpenInvite(true)
+  }
   //#endregion
 
   //#region Component Api methods
@@ -116,7 +122,7 @@ const Dashboard = () => {
           }}
         >
           <PersonalTracker setOpenAddExpense={setOpenAddExpense}/>
-          <TeamTracker teamDetails={teamDetails} setCreateTeam={setCreateTeam} />
+          <TeamTracker teamDetails={teamDetails} setCreateTeam={setCreateTeam} openInvite={openInvite} setOpenInvite={handleInviteButtonClick} handleClose={() => setOpenInvite(false)} />
         </Box>
       </Box>
 
@@ -127,7 +133,9 @@ const Dashboard = () => {
     {openAddExpense && (
         <AddExpense openAddExpense={openAddExpense} setOpenAddExpense={setOpenAddExpense}/>
     )}
- 
+  {openInvite && (
+    <Invite openInvite={openInvite} handleClose={() => setOpenInvite(false)}/>
+  )}
  </Box>
   );
   //#endregion

--- a/src/config/RoutesConfig.jsx
+++ b/src/config/RoutesConfig.jsx
@@ -60,11 +60,11 @@ const RoutesConfig = () => {
         element : <LandingPage> <Dashboard /> </LandingPage>
     },
     {
-        path : "/myexpense",
+        path : "/expenselist/:groupId?",
         element : <LandingPage> <ExpenseListPage /> </LandingPage>
     },
-    {
-        path : "/expenselist/:groupId?",
+     {
+        path : "/teamexpense",
         element : <LandingPage> <ExpenseListPage /> </LandingPage>
     },
     {


### PR DESCRIPTION
This PR introduces the Invite component, a modal interface for managing team invitations. It provides UI functionality for inviting new members by email, viewing current members, checking pending requests, and copying a team invite link.

What's New / Implemented:
✅ Invite Modal: Built using MUI's Modal and Box components to create a centered, scrollable interface.

✅ Email Invitation: Input field and button to simulate sending invites to a team member.

✅ Tabs for Members and Pending Requests:

Toggle between "Members" and "Pending Requests" using a stateful view.

Uses dummy data (membersList and user) to simulate the toggle.

✅ Members List Display: Renders each member using the Members component with avatar, email, and role details.

✅ Team Invite Link Section: TextField to display an invite link with a "Copy Link" button (pending clipboard logic).

✅ Responsive Layout: Uses Box and MUI grid system for responsive spacing and layout.

