### PR TITLE
fix: modify auth and group slice to include redux thunk middleware

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "react-icons": "^5.5.0",
         "react-redux": "^9.2.0",
         "react-router-dom": "^7.6.0",
+        "react-toastify": "^11.0.5",
         "tailwind-scrollbar-hide": "^2.0.0",
         "tailwindcss": "^4.1.5"
       },
@@ -5130,6 +5131,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/react-toastify": {
+      "version": "11.0.5",
+      "resolved": "https://registry.npmjs.org/react-toastify/-/react-toastify-11.0.5.tgz",
+      "integrity": "sha512-EpqHBGvnSTtHYhCPLxML05NLY2ZX0JURbAdNYa6BUkk+amz4wbKBQvoKQAB0ardvSarUBuY4Q4s1sluAzZwkmA==",
+      "license": "MIT",
+      "dependencies": {
+        "clsx": "^2.1.1"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19",
+        "react-dom": "^18 || ^19"
       }
     },
     "node_modules/react-transition-group": {

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "react-icons": "^5.5.0",
     "react-redux": "^9.2.0",
     "react-router-dom": "^7.6.0",
+    "react-toastify": "^11.0.5",
     "tailwind-scrollbar-hide": "^2.0.0",
     "tailwindcss": "^4.1.5"
   },

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -4,10 +4,13 @@ import './index.css'
 import App from './App.jsx'
 import { Provider } from 'react-redux'
 import { store } from './redux/store.js'
+import { ToastContainer } from 'react-toastify';
+import 'react-toastify/dist/ReactToastify.css';
 
 
 createRoot(document.getElementById('root')).render(
   <Provider store={store}>
     <App />
+    <ToastContainer position="top-center" autoClose={3000} />
   </Provider>
 )

--- a/src/redux/authSlice.js
+++ b/src/redux/authSlice.js
@@ -1,25 +1,111 @@
 import { createSlice } from "@reduxjs/toolkit";
-
+import { createAsyncThunk } from "@reduxjs/toolkit";
 
 const initialState = {
     user: null,
-    isLoggedIn: false,
+    loading: false,
+    error: null
 };
+
+export const register = createAsyncThunk('create', async (user, { rejectWithValue }) => {
+    try {
+        const response = await fetch('http://localhost:3000/auth/signup', {
+            method: 'POST',
+            headers: {
+                "Content-type": "Application/json"
+            },
+            body: JSON.stringify(user)
+        });
+        const result = await response.json();
+        return result;
+
+    } catch (error) {
+        rejectWithValue(error);
+    }
+})
+
+export const login = createAsyncThunk('login', async (user, { rejectWithValue }) => {
+    try {
+        const response = await fetch('http://localhost:3000/auth/login',
+            {
+                method: 'POST',
+                headers: {
+                    "Content-type": "Application/json"
+                },
+                body: JSON.stringify(user)
+
+            },
+        );
+        const result = await response.json();
+        return result;
+
+    } catch (error) {
+        rejectWithValue(error);
+    }
+})
+
+export const logout = createAsyncThunk('logout', async ({ rejectWithValue }) => {
+    try {
+        const response = await fetch('http://localhost:3000/auth/logout', {
+            method: 'POST',
+            headers: {
+                "Content-type": "Application/json"
+            },
+        });
+        const result = await response.json();
+        return result
+    } catch (error) {
+        rejectWithValue(error);
+    }
+})
 
 const authSlice = createSlice({
     name: "auth",
     initialState,
-    reducers: {
-        login: (state, action) => {
-            state.user = action.payload;
-            state.isLoggedIn = true;
-        },
-        logout: (state) => {
-            state.user = null;
-            state.isLoggedIn = false;
-        }
+    extraReducers: (builder) => {
+        builder
+            //Register
+            .addCase(register.pending, (state) => {
+                state.loading = true;
+            })
+            .addCase(register.fulfilled, (state, action) => {
+                state.loading = false;
+                state.user = action.payload;
+                state.error = null;
+            })
+            .addCase(register.rejected, (state, action) => {
+                state.loading = false;
+                state.error = action.payload;
+            })
+
+            //Login
+            .addCase(login.pending, (state) => {
+                state.loading = true;
+            })
+            .addCase(login.fulfilled, (state, action) => {
+                state.loading = false;
+                state.user = action.payload;
+                state.error = null;
+            })
+            .addCase(login.rejected, (state, action) => {
+                state.loading = false;
+                state.error = action.payload;
+            })
+
+            //Logout
+            .addCase(logout.pending, (state) => {
+                state.loading = true
+            })
+            .addCase(logout.fulfilled, (state, action) => {
+                state.loading = false;
+                state.user = action.payload;
+                state.error = null;
+            })
+            .addCase(logout.rejected, (state, action) => {
+                state.loading = false;
+                state.error = action.payload;
+            })
     }
 });
 
-export const { login, logout } = authSlice.actions;
 export default authSlice.reducer;

--- a/src/redux/expenseSlice.js
+++ b/src/redux/expenseSlice.js
@@ -1,27 +1,36 @@
 import { createSlice } from '@reduxjs/toolkit'
+import { createAsyncThunk } from '@reduxjs/toolkit';
 
 const initialState = {
-    expenses: []
-};
+    expenses: [],
+    loading: false,
+    error: null
+}; 
 
 const expenseSlice = createSlice({
     name: 'expense',
     initialState,
-    reducers: {
+    extraReducers: (builder) => {
+        builder
+
+        //
+        addCase()
+
         addExpense: (state, action) => {
+
             state.expenses = [...state.expenses, action.payload]
         },
-        removeExpense: (state, action) => {
-            state.expenses = state.expenses.filter(expense => expense._id !== action.payload)
-        },
-        updateExpense: (state, action) => {
-            state.expenses = state.expenses.map(expense => (
-                expense._id.toString() === action.payload._id.toString() && action.payload
-            ))
-        },
-        setExpenses: (state, action) => {
-            state.expenses = action.payload;
-        }
+            removeExpense: (state, action) => {
+                state.expenses = state.expenses.filter(expense => expense._id !== action.payload)
+            },
+                updateExpense: (state, action) => {
+                    state.expenses = state.expenses.map(expense => (
+                        expense._id.toString() === action.payload._id.toString() && action.payload
+                    ))
+                },
+                    setExpenses: (state, action) => {
+                        state.expenses = action.payload;
+                    }
     },
 });
 

--- a/src/redux/groupSlice.js
+++ b/src/redux/groupSlice.js
@@ -1,36 +1,190 @@
 import { createSlice } from "@reduxjs/toolkit";
+import { createAsyncThunk } from "@reduxjs/toolkit";
 
 const initialState = {
     groups: [],
     isAddGroupFormOpen: false,
+    loading: false,
+    error: null
 }
+
+export const createGroup = createAsyncThunk('createGroup', async (data, { rejectWithValue }) => {
+    try {
+
+        const response = await fetch('/api', {
+            method: 'POST',
+            headers: {
+                "Content-type": "Application/json"
+            },
+            body: JSON.stringify(data)
+        });
+        const result = await response.json();
+        return result;
+
+    } catch (error) {
+        rejectWithValue(error);
+    }
+});
+
+export const updateGroup = createAsyncThunk('updateGroup', async ({ data, groupId }, { rejectWithValue }) => {
+    try {
+
+        const response = await fetch(`/api/${groupId}`, {
+            method: 'PORT',
+            headers: {
+                "Content-type": "Application/json"
+            },
+            body: JSON.stringify(data)
+        });
+        const result = await response.json();
+        return result;
+
+    } catch (error) {
+        rejectWithValue(error)
+    }
+});
+
+export const removeUser = createAsyncThunk('removeUser', async ({ groupId, userId }, { rejectWithValue }) => {
+    try {
+
+        const response = await fetch(`/api/${groupId}/${userId}`, {
+            method: 'POST',
+            headers: {
+                "Content-type": "Application/json"
+            },
+        });
+
+        const result = await response.json();
+        return result;
+
+    } catch (error) {
+        rejectWithValue(error)
+    }
+});
+
+export const deleteGroup = createAsyncThunk('deleteGroup', async (groupId, { rejectWithValue }) => {
+    try {
+
+        const response = await fetch(`/api/${groupId}`, {
+            method: 'POST',
+            headers: {
+                "Content-type": "Application/json"
+            },
+        });
+        const result = await response.json();
+        return result;
+
+    } catch (error) {
+        rejectWithValue(error)
+    }
+});
+
+export const getAllGroup = createAsyncThunk('getAllGroup', async (_, { rejectWithValue }) => {
+    try {
+
+        const response = await fetch(`/api`, {
+            method: 'GET',
+            headers: {
+                "Content-type": "Application/json",
+            },
+        });
+
+        const result = await response.json();
+        return result;
+
+    } catch (error) {
+        rejectWithValue(error);
+    }
+})
 
 const groupSlice = createSlice({
     name: 'Group',
     initialState,
     reducers: {
-        setGroups: (state, action) => {
-            state.groups = action.payload
-        },
-        addGroup: (state, action) => {
-            state.groups = [...state.groups, action.payload];
-        },
-        removeGroup: (state, action) => {
-            state.groups = state.groups.filter(group => group._id !== action.payload)
-        },
-        updateGroup: (state, action) => {
-            state.groups = state.groups.map(group => (
-                group._id.toString() === action.payload._id.toString() ? (
-                    { ...group, groupName: action.payload.groupName }
-                ) : group
-            ))
-        },
         toggleAddGroupForm: (state) => {
             state.isAddGroupFormOpen = !state.isAddGroupFormOpen
         }
-    }
+    },
+    extraReducers: (builder) => {
+        builder
+            //getAllGroup
+            .addCase(getAllGroup.pending, (state) => {
+                state.loading = true;
+            })
+            .addCase(getAllGroup.fulfilled, (state, action) => {
+                state.loading = false;
+                state.groups = action.payload;
+                state.error = null;
+            })
+            .addCase(getAllGroup.rejected, (state, action) => {
+                state.loading = false;
+                state.error = action.payload;
+            })
 
+            //createGroup
+            .addCase(createGroup.pending, (state) => {
+                state.loading = true;
+            })
+            .addCase(createGroup.fulfilled, (state, action) => {
+                state.loading = true;
+                state.groups.push(action.payload);
+                state.error = null;
+            })
+            .addCase(createGroup.rejected, (state, action) => {
+                state.loading = false;
+                state.error = action.payload;
+            })
+
+            //updateGroup
+            .addCase(updateGroup.pending, (state) => {
+                state.loading = true;
+            })
+            .addCase(updateGroup.fulfilled, (state, action) => {
+                state.loading = false;
+                state.groups = state.groups.map(group => group._id.toString() === action.payload._id.toString() ? action.payload : group);
+                state.error = null;
+            })
+            .addCase(updateGroup.rejected, (state, action) => {
+                state.loading = false;
+                state.error = action.payload;
+            })
+
+            //removeUserFromGroup
+            .addCase(removeUser.pending, (state) => {
+                state.loading = true;
+            })
+            .addCase(removeUser.fulfilled, (state, action) => {
+                state.pending = false;
+                state.groups = state.groups.map(group => {
+                    if (group.members.some(user => user._id === action.payload)) {
+                        return {
+                            ...group,
+                            members: group.members.filter(user => user._id !== action.payload)
+                        };
+                    };
+                });
+                state.error = null;
+            })
+            .addCase(removeUser.rejected, (state, action) => {
+                state.loading = false;
+                state.error = action.payload;
+            })
+
+            //removeGroup
+            .addCase(deleteGroup.pending, (state) => {
+                state.loading = true;
+            })
+            .addCase(deleteGroup.fulfilled, (state, action) => {
+                state.loading = false;
+                state.groups = state.groups.filter(group => group._id.toString() !== action.payload.toString());
+                state.error = null;
+            })
+            .addCase(deleteGroup.rejected, (state, action) => {
+                state.loading = false;
+                state.error = action.payload;
+            })
+    }
 });
 
-export const { addGroup, removeGroup, updateGroup, toggleAddGroupForm } = groupSlice.actions;
+export const { toggleAddGroupForm } = groupSlice.actions;
 export default groupSlice.reducer;


### PR DESCRIPTION
fix: modify auth and group slice to include redux thunk middleware to call all the apis inside redux only to manage the apis and redux correctly and easily.

fix: add and configure react toastify for notification purpose